### PR TITLE
Add missing fields to en/bible.en.leb.2010

### DIFF
--- a/en/bible.en.leb.2010.xml
+++ b/en/bible.en.leb.2010.xml
@@ -6,6 +6,8 @@
 <title>The Lexham English Bible</title>
 <creator type='x-edt'>W. Hall Harris III</creator>
 <date>2010-03-23</date>
+<identifier>Bible.EN.LEB.2010</identifier>
+<description/>
 <publisher>Logos Research Systems, Inc.</publisher>
 <type type='OSIS'>Bible</type>
 <format type='x-MIME'>text/xml</format>


### PR DESCRIPTION
`en/bible.en.leb.2010` is missing some metadata tags, so let's add them. All other books seem to contain non-empty `identifier` and (possibly empty) `description` fields.